### PR TITLE
Feedback

### DIFF
--- a/feedback/defensive-colmeans-sol.Rmd
+++ b/feedback/defensive-colmeans-sol.Rmd
@@ -1,0 +1,71 @@
+```{r, child = "defensive-colmeans-ex.Rmd"}
+```
+
+----------------------------------------------------
+
+### Lösung:
+
+
+Minimalstlösung:
+```{r, col_means_def_1}
+# compute means of all numeric columns in <data>
+# input: a data.frame 
+# output: a data.frame containing the column means
+col_means <- function(data) {
+  stopifnot(is.data.frame(data), all(dim(data)) > 0)
+
+  numeric <- sapply(data, is.numeric)
+  data_numeric <- data[, numeric, drop = FALSE]
+
+  data.frame(vapply(data_numeric, mean, numeric(1)))
+}
+```
+```{r, col_means_test, error = TRUE}
+```
+
+Etwas ausgefeilter:
+```{r, col_means_def_2}
+# compute means of all columns in data for whose class "mean" is defined
+# data: anything that can be converted to a data.frame
+# na.rm: drop NAs?
+# output: a data.frame containing the column means of all numeric columns
+col_means <- function(data, na.rm = FALSE) {
+  checkmate::assert_flag(na.rm)
+  if (!is.data.frame(data)) {
+    data <- try(as.data.frame(data))
+    if (inherits(data, "try-error")) {
+      stop("<data> not convertable to a data.frame")
+    } else {
+      message("<data> converted to data.frame.")
+    }
+  }
+
+  # selecting columns for which mean can be computed:
+  use <- vapply(data, has_mean, logical(1))
+  # drop = FALSE so single columns work as expected!
+  data_numeric <- data[, use, drop = FALSE]
+  
+  # check for zero dims *after* selecting columns so all-character
+  # and all-factor data.frames get picked up as well.
+  if (any(dim(data_numeric) == 0)) {
+    rows_columns_zero <- as.character(c(10, 1) %*% (dim(data_numeric) == 0))
+    warning("<data> has zero ", 
+      switch(rows_columns_zero, 
+        "1"  = "columns", 
+        "10" = "rows", 
+        "11" = "rows and columns"), 
+      " for which a mean-method is defined")
+    return(data.frame())
+  }
+  
+  as.data.frame(lapply(data_numeric, mean, na.rm = na.rm))
+}
+# see methods("mean") for data types with mean-method
+has_mean <- function(x) {
+  is.numeric(x) |
+    inherits(x, what = c("Date", "POSIXct", "POSIXlt", "difftime"))
+}
+
+```
+```{r, col_means_test, error=TRUE}
+```

--- a/feedback/defensive-count-sol.Rmd
+++ b/feedback/defensive-count-sol.Rmd
@@ -1,0 +1,66 @@
+```{r, child = "defensive-count-ex.Rmd"}
+```
+
+----------------------------------------------------
+
+### Lösung:
+
+a)  
+
+Implizite Annahmen über `supposedly_a_count` von denen abhängt ob der 
+ursprünglichen Code das erwartete Verhalten hat:
+
+- `supposedly_a_count` ist was numerisches
+- `supposedly_a_count` hat Länge 1
+- `supposedly_a_count` ist nicht `NA` oder `NaN`
+- `supposedly_a_count` ist nicht negativ
+- `supposedly_a_count` ist nicht unendlich
+
+
+b)  
+
+Strenge Variante:
+```{r, eval = FALSE}
+count_them <- function(supposedly_a_count) {
+  checkmate::assert_number(supposedly_a_count,
+                           lower = 0, finite = TRUE,
+                           null.ok = FALSE, na.ok = FALSE
+  ) # defaults, not necessary
+  if (!checkmate::test_count(supposedly_a_count)) {
+    warning(
+      "rounding ", supposedly_a_count,
+      "to the nearest integer."
+    )
+    supposedly_a_count <- round(supposedly_a_count)
+  }
+  #always return an integer:
+  as.integer(supposedly_a_count)
+}  
+```
+
+Nachsichtigere Variante:
+```{r, eval = FALSE}
+count_them <- function(supposedly_a_count) {
+  if (length(supposedly_a_count) > 1) {
+    warning("only using first element of supposedly_a_count")
+    supposedly_a_count <- supposedly_a_count[1]
+  }
+  checkmate::assert_number(supposedly_a_count, finite = TRUE)
+  if (!checkmate::test_count(supposedly_a_count)) {
+    warning(
+      "rounding ", supposedly_a_count,
+      "to the nearest non-negative integer."
+    )
+    as.integer(max(0, round(supposedly_a_count)))
+  }
+}
+```
+
+Zu pragmatische Variante (ohne Warnungen, und die erste Zeile könnte schiefgehen...):
+```{r, eval = FALSE}
+count_them <- function(supposedly_a_count) {
+  supposedly_a_count <- round(as.numeric(supposedly_a_count[1]))
+  checkmate::assert_count(supposedly_a_count)
+  as.integer(supposedly_a_count)
+}  
+```

--- a/feedback/defensive-lag-sol.Rmd
+++ b/feedback/defensive-lag-sol.Rmd
@@ -1,0 +1,35 @@
+```{r, child = "defensive-lag-ex.Rmd"}
+```
+
+----------------------------------------------------
+### Lösung:
+
+Zum Beispiel:
+```{r, lag-def}
+# make a lagged version of x
+# inputs: x: a vector
+#         lag: how many lags?
+lag <- function(x, lag = 1L) {
+  checkmate::assert_atomic_vector(x, min.len = 1)
+  checkmate::assert_count(lag)
+  checkmate::assert_number(lag, upper = length(x))
+  c(rep(NA, lag), x[seq_len(length(x) - lag)])
+}
+```
+```{r, lag-test, error=TRUE}
+x <- seq_len(10)
+
+testthat::expect_equal(lag(x, 2), c(NA, NA, x[1:8]))
+testthat::expect_equal(lag(x, 0), x)
+testthat::expect_equal(lag(x, 10), rep(NA_integer_, 10))
+
+# these should all give errors that are triggered by input checks:
+testthat::expect_error(lag(list(1, 2)))
+testthat::expect_error(lag(matrix(1:2, 1, 2)))
+testthat::expect_error(lag(data.frame(1, 2)))
+
+testthat::expect_error(lag(x, 11))
+testthat::expect_error(lag(x, -1))
+testthat::expect_error(lag(x, c(1, 3)))
+testthat::expect_error(lag(x, .2))
+```


### PR DESCRIPTION
@AntonioMelieni 

jawoll, schön dran bleiben dann geht was voran :)

------------------------------------

*`colmeans`*:

nja, so ungefähr. vgl musterlösung.

es fehlen komplett alle **input checks** (very very bad!), es fehlt der kommentar drüber *was tut das, was für inputs, was für output* (very bad!), und für eine einzige funktion `tidyverse` zu laden ist eher overkill.... 

- https://github.com/fort-w2021/defensive-ex-AntonioMelieni/blob/d1fb282c90e0636e4707a33295fb291ccaaf3417/Abgabe/defensive-colmeans-sol.R#L13 das hätte hier ein *early exit* sein sollen, oder? dann fehlt hier ein `return(df)`, außerdem 
bitte nicht ohne guten grund die inputs der funktion mit irgendwas überschreiben. macht den code schwer verständlich wenn `df` in zeile 1 was ganz anderes ist als in zeile 20 und dann wieder in zeile 100. hier wurscht weil eh alles klar  & kurz, bei komplexen programmen aber wichtig. 

---------------------------------

*`count`*

funktionsumfang stellt mich zufrieden, gut!

kommentar drüber *was tut das, was für inputs, was für output*  fehlt.

bitte in zukunft versuchen möglichst viele annahmen mit den argumenten der `assert_BLA` funktionen *in one go* abzuprüfen --  
Der ganze Block hier https://github.com/fort-w2021/defensive-ex-AntonioMelieni/blob/d1fb282c90e0636e4707a33295fb291ccaaf3417/Abgabe/defensive-count-sol.Rmd#L12-L16
ist einfach `assert_number(supposedly_a_count, lower = 0, finite = TRUE, na.ok = FALSE)` -- **KIS**!

https://github.com/fort-w2021/defensive-ex-AntonioMelieni/blob/d1fb282c90e0636e4707a33295fb291ccaaf3417/Abgabe/defensive-count-sol.Rmd#L27  hätte noch ein `as.integer` vertragen, `round` gibt `double` zurück.

--------------------------------------------

*`lag`* 

passt weitestgehend!

kommentar drüber *was tut das, was für inputs, was für output*  fehlt.

https://github.com/fort-w2021/defensive-ex-AntonioMelieni/blob/d1fb282c90e0636e4707a33295fb291ccaaf3417/Abgabe/defensive-lag-sol.Rmd#L8
kompakter  wäre `if(!is.vector(x))`, aber ok, das ist geschmackssache...
wichtiger: das `is.vector` schlägt für `list` nicht an, denn auch eine `list` ist ein `vector` in `R`. Vermute du hättest hier eher `checkmate::test_atomic_vector`  oder `checkmate::assert_atomic_vector` gewollt, was dann eben wirklich bei listen hier `FALSE` zurückgibt bzw abbricht .

https://github.com/fort-w2021/defensive-ex-AntonioMelieni/blob/d1fb282c90e0636e4707a33295fb291ccaaf3417/Abgabe/defensive-lag-sol.Rmd#L13 
eher überspezifisch -- warum darf `lag` nicht auch 0 sein? 
eher user-unfreundliches interface --reicht ja dass es ne ganze zahl ist, dafür muss es ja nicht unbedingt als `integer` abgespeichert sein....
